### PR TITLE
Add org.nrg948.autonomous package

### DIFF
--- a/nrgcommon/src/main/java/org/nrg948/autonomous/Autonomous.java
+++ b/nrgcommon/src/main/java/org/nrg948/autonomous/Autonomous.java
@@ -1,0 +1,79 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package org.nrg948.autonomous;
+
+import static org.reflections.scanners.Scanners.SubTypes;
+import static org.reflections.util.ReflectionUtilsPredicates.withAnnotation;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.reflections.Reflections;
+import org.reflections.util.ConfigurationBuilder;
+
+import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
+import edu.wpi.first.wpilibj2.command.Command;
+
+/** A class containing utility methods to support autonomous operation. */
+public final class Autonomous {
+
+  /**
+   * Returns a {@link SendableChooser} object enabling interactive selection of
+   * autonomous commands annotated with {@link AutonomousCommand}.
+   * 
+   * @param <T>       The container type.
+   * @param container An object passed to the constructor of the automonous
+   *                  commands providing access to the robot subsystems. This
+   *                  is typically an instance of RobotContainer but could be
+   *                  another type that manages the subsystems.
+   * @param pkgs      The packages to scan for {@link Command} subclasses
+   *                  annotated with {@link AutonomousCommand}.
+   * 
+   * @return A {@link SendableChooser} object containing the autonomous commands.
+   */
+  public static <T> SendableChooser<Command> getChooser(T container, String... pkgs) {
+    Reflections reflections = new Reflections(new ConfigurationBuilder().forPackages(pkgs));
+    SendableChooser<Command> chooser = new SendableChooser<>();
+    Class<? extends Object> containerClass = container.getClass();
+
+    reflections.get(SubTypes.of(Command.class).asClass().filter(withAnnotation(AutonomousCommand.class)))
+        .stream()
+        .forEach(cc -> {
+          try {
+            AutonomousCommand annotation = cc.getAnnotation(AutonomousCommand.class);
+            Command command = (Command) cc.getConstructor(containerClass).newInstance(container);
+
+            chooser.addOption(annotation.name(), command);
+
+            if (annotation.isDefault()) {
+              chooser.setDefaultOption(annotation.name(), command);
+            }
+          } catch (NoSuchMethodException e) {
+            System.err.printf(
+                "ERROR: Class %s does not define the public constructor: %s(%s)%n",
+                cc.getName(),
+                cc.getSimpleName(),
+                containerClass.getSimpleName());
+            e.printStackTrace();
+          } catch (
+              InstantiationException
+              | IllegalAccessException
+              | IllegalArgumentException
+              | ClassCastException
+              | InvocationTargetException
+              | SecurityException e) {
+            System.err.printf(
+                "ERROR: An unexpected exception was caught while creating an instance of %s.%n",
+                cc.getName());
+            e.printStackTrace();
+          }
+        });
+
+    return chooser;
+  }
+
+  private Autonomous() {
+
+  }
+}

--- a/nrgcommon/src/main/java/org/nrg948/autonomous/AutonomousCommand.java
+++ b/nrgcommon/src/main/java/org/nrg948/autonomous/AutonomousCommand.java
@@ -1,0 +1,39 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package org.nrg948.autonomous;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
+import edu.wpi.first.wpilibj2.command.Command;
+
+/**
+ * Annotates a class implementing a subclass of {@link Command} to run during
+ * autonomous.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AutonomousCommand {
+    /**
+     * The name to display for the annotated {@link Command} in the
+     * {@link SendableChooser} returned by
+     * {@link Autonomous#getChooser(Object, String...)}.
+     * 
+     * @return The display name.
+     */
+    String name();
+
+    /**
+     * Whether this command is the default {@link Command} in the
+     * {@link SendableChooser} returned by
+     * {@link Autonomous#getChooser(Object, String...)}.
+     * 
+     * @return Returns true if this is the default command, and false otherwise.
+     */
+    boolean isDefault() default false;
+}


### PR DESCRIPTION
* Adds the `AutonomousCommand` annotation used to annotate subclasses of `Command` representing autonomous routines.
* Adds the `Autonomous.getChooser()` method that builds a `SendableChooser` of `Command` subclasses annotated with `AutonomousCommand`. This can be sent to the Shuffleboard or SmartDashboard to enable interactive selection of a command to run during autonomous.